### PR TITLE
Fix empty sidebar when no headings

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -163,6 +163,11 @@ document.addEventListener("DOMContentLoaded", function () {
             hasInnerContainers: true,
             collapseDepth: 6
         });
+    } else {
+        const sidebarEl = document.querySelector('.gh-sidebar');
+        if (sidebarEl) {
+            sidebarEl.style.display = 'none';
+        }
     }
 
     document.querySelectorAll('.gh-toc a[href^="#"]').forEach(function (anchor) {


### PR DESCRIPTION
## Summary
- hide the floating sidebar if the page contains no headings

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684137ca36188329ba15e87c49e97e63